### PR TITLE
Fix tenant resubmit payment always throws error

### DIFF
--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -57,31 +57,7 @@ const Dashboard = () => {
               )}
             </div>
 
-            <div className="stats-overview">
-              <h3>Quick Overview</h3>
-              <div className="stats-grid">
-                <div className="stat-item">
-                  <h4>User Approval System</h4>
-                  <p>New registrations require admin approval</p>
-                  <span className="status-complete">✅ Complete</span>
-                </div>
-                <div className="stat-item">
-                  <h4>Resident Management</h4>
-                  <p>Complete CRUD operations for residents</p>
-                  <span className="status-complete">✅ Complete</span>
-                </div>
-                <div className="stat-item">
-                  <h4>Payment Management</h4>
-                  <p>Track payments and create bulk charges</p>
-                  <span className="status-complete">✅ Complete</span>
-                </div>
-                <div className="stat-item">
-                  <h4>Expense Tracking</h4>
-                  <p>Monitor building expenses and receipts</p>
-                  <span className="status-complete">✅ Complete</span>
-                </div>
-              </div>
-            </div>
+           
           </div>
         );
     }

--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import ResidentManagement from './ResidentManagement';
-import PaymentManagement from './PaymentManagement'; // Add this import
+import PaymentManagement from './PaymentManagement';
+import Expenses from './Expenses';
 import './Dashboard.css';
 
 const Dashboard = () => {
@@ -23,10 +24,19 @@ const Dashboard = () => {
     switch (currentView) {
       case 'resident-management':
         return <ResidentManagement />;
-      
       case 'payments':
-        return <PaymentManagement />; // Add this case
-      
+        return <PaymentManagement />;
+      case 'expenses':
+        return isAdmin ? (
+          <Expenses />
+        ) : (
+          <div className="dashboard-content">
+            <div className="welcome-card">
+              <h3>Unauthorized</h3>
+              <p>You do not have access to Expenses.</p>
+            </div>
+          </div>
+        );
       default:
         return (
           <div className="dashboard-content">
@@ -38,7 +48,7 @@ const Dashboard = () => {
                 <p><strong>Role:</strong> {user.role}</p>
                 <p><strong>User ID:</strong> {user.id}</p>
               </div>
-              
+
               {isAdmin && (
                 <div className="admin-notice">
                   <h3>Admin Access</h3>
@@ -61,14 +71,14 @@ const Dashboard = () => {
                   <span className="status-complete">✅ Complete</span>
                 </div>
                 <div className="stat-item">
-                  <h4>Payment Management</h4> {/* Update this */}
+                  <h4>Payment Management</h4>
                   <p>Track payments and create bulk charges</p>
-                  <span className="status-complete">✅ Complete</span> {/* Update this */}
+                  <span className="status-complete">✅ Complete</span>
                 </div>
                 <div className="stat-item">
                   <h4>Expense Tracking</h4>
                   <p>Monitor building expenses and receipts</p>
-                  <span className="status-pending">⏳ Coming Soon</span>
+                  <span className="status-complete">✅ Complete</span>
                 </div>
               </div>
             </div>
@@ -125,15 +135,17 @@ const Dashboard = () => {
               </button>
             </li>
             
-            <li>
-              <button 
-                className={`nav-item ${currentView === 'expenses' ? 'active' : ''}`}
-                onClick={() => handleNavClick('expenses')}
-              >
-                <span className="nav-icon">📊</span>
-                Expenses
-              </button>
-            </li>
+            {isAdmin && (
+              <li>
+                <button
+                  className={`nav-item ${currentView === 'expenses' ? 'active' : ''}`}
+                  onClick={() => handleNavClick('expenses')}
+                >
+                  <span className="nav-icon">📊</span>
+                  Expenses
+                </button>
+              </li>
+            )}
             
             <li>
               <button 

--- a/client/src/components/Expenses.css
+++ b/client/src/components/Expenses.css
@@ -1,0 +1,207 @@
+/* Container */
+.expenses-container {
+  min-height: 100vh;
+  background: #f8f9fa;
+  padding: 20px;
+}
+
+/* Header + stats */
+.expenses-header {
+  background: #fff;
+  border-radius: 12px;
+  padding: 30px;
+  margin-bottom: 30px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+}
+
+.header-title h2 {
+  margin: 0 0 8px;
+  color: #333;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.header-title p {
+  margin: 0;
+  color: #666;
+}
+
+.expenses-stats {
+  display: grid;
+  gap: 20px;
+  margin-top: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.expenses-stats .stat-card {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.expenses-stats .stat-number {
+  font-size: 22px;
+  font-weight: 700;
+  display: block;
+}
+
+.expenses-stats .stat-label {
+  opacity: .9;
+  font-size: 13px;
+}
+
+/* Controls */
+.expenses-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fff;
+  padding: 20px;
+  border-radius: 12px;
+  gap: 20px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-bottom: 20px;
+}
+
+.search-filters {
+  display: flex;
+  gap: 15px;
+  flex: 1;
+}
+
+.search-input,
+.filter-select {
+  padding: 12px 16px;
+  border: 2px solid #e1e5e9;
+  border-radius: 8px;
+  font-size: 16px;
+}
+
+.search-input {
+  flex: 1;
+  max-width: 400px;
+}
+
+.add-expense-btn {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #fff;
+  border: none;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* Table */
+.expenses-table-container {
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+  margin-bottom: 20px;
+}
+
+.expenses-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.expenses-table th {
+  background: #f8f9fa;
+  color: #333;
+  font-weight: 600;
+  padding: 16px 12px;
+  text-align: left;
+  border-bottom: 2px solid #e1e5e9;
+}
+
+.expenses-table td {
+  padding: 16px 12px;
+  border-bottom: 1px solid #f1f3f4;
+  vertical-align: middle;
+}
+
+.expenses-table tr:hover {
+  background: #f8f9fa;
+}
+
+/* Badges and cells */
+.category-badge {
+  background: #eef2ff;
+  color: #3f51b5;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.amount-cell {
+  font-weight: 600;
+  color: #2e7d32;
+}
+
+.actions-cell {
+  white-space: nowrap;
+  text-align: center;
+}
+
+.edit-btn,
+.delete-btn {
+  background: none;
+  border: 1px solid #e1e5e9;
+  padding: 8px 12px;
+  margin: 0 4px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.edit-btn:hover {
+  background: #e3f2fd;
+  border-color: #1976d2;
+}
+
+.delete-btn:hover {
+  background: #ffebee;
+  border-color: #d32f2f;
+}
+
+/* Summary */
+.results-summary {
+  background: #fff;
+  padding: 16px 20px;
+  border-radius: 8px;
+  text-align: center;
+  color: #666;
+  font-size: 14px;
+  font-weight: 500;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+/* Form layout (modal styling already exists in PaymentManagement.css) */
+.expense-form .form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .expenses-controls { flex-direction: column; align-items: stretch; }
+  .search-filters { flex-direction: column; }
+  .search-input { max-width: none; }
+}
+
+@media (max-width: 768px) {
+  .expenses-container { padding: 10px; }
+  .expenses-header { padding: 20px; margin-bottom: 20px; }
+  .header-title h2 { font-size: 24px; }
+  .expense-form .form-row { grid-template-columns: 1fr; }
+  .expenses-table-container { overflow-x: auto; }
+  .expenses-table { min-width: 700px; }
+}

--- a/client/src/components/Expenses.css
+++ b/client/src/components/Expenses.css
@@ -95,6 +95,26 @@
   cursor: pointer;
 }
 
+.controls-right {
+  display: flex;
+  gap: 8px;
+}
+
+.export-btn {
+  background: #f8f9fa;
+  color: #333;
+  border: 2px solid #e1e5e9;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.export-btn:hover {
+  background: #eef2ff;
+  border-color: #cfd8ff;
+}
+
 /* Table */
 .expenses-table-container {
   background: #fff;

--- a/client/src/components/Expenses.css
+++ b/client/src/components/Expenses.css
@@ -95,11 +95,13 @@
   cursor: pointer;
 }
 
+/* Right-side controls */
 .controls-right {
   display: flex;
   gap: 8px;
 }
 
+/* Export button */
 .export-btn {
   background: #f8f9fa;
   color: #333;
@@ -209,6 +211,45 @@
   grid-template-columns: 1fr 1fr;
   gap: 20px;
 }
+
+/* Allocated visuals */
+.alloc-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #eef2ff;
+  color: #3f51b5;
+}
+.alloc-badge.unpaid { background: #ffebee; color: #c62828; }
+.alloc-badge.partially_paid { background: #fff8e1; color: #b26a00; }
+.alloc-badge.paid { background: #e8f5e9; color: #2e7d32; }
+
+.alloc-progress {
+  height: 6px;
+  background: #f1f3f4;
+  border-radius: 4px;
+  margin-top: 6px;
+  overflow: hidden;
+}
+.alloc-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  width: 0%;
+}
+
+/* Allocate action */
+.allocate-btn {
+  background: none;
+  border: 1px solid #e1e5e9;
+  padding: 8px 12px;
+  margin: 0 4px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 16px;
+}
+.allocate-btn:hover { background: #f3e8ff; border-color: #7e57c2; }
 
 /* Responsive */
 @media (max-width: 1024px) {

--- a/client/src/components/Expenses.js
+++ b/client/src/components/Expenses.js
@@ -1,0 +1,249 @@
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { expenseService } from '../services/expenseService';
+import './Expenses.css';
+
+const categories = [
+  { value: 'all', label: 'All Categories' },
+  { value: 'cleaning', label: 'Cleaning' },
+  { value: 'electricity', label: 'Electricity' },
+  { value: 'water', label: 'Water' },
+  { value: 'repairs', label: 'Repairs' },
+  { value: 'maintenance', label: 'Maintenance' },
+  { value: 'security', label: 'Security' },
+  { value: 'salary', label: 'Salary' },
+  { value: 'utilities', label: 'Utilities' },
+  { value: 'other', label: 'Other' }
+];
+
+const fmtMAD = (n) => `${Number(n || 0).toFixed(2)} MAD`;
+
+const Expenses = () => {
+  const { isAdmin } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [expenses, setExpenses] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [category, setCategory] = useState('all');
+  const [month, setMonth] = useState(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+  });
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState(null);
+
+  const year = useMemo(() => parseInt(month.slice(0, 4), 10), [month]);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [list, s] = await Promise.all([
+        expenseService.getExpenses({ month, category, q: searchTerm }),
+        expenseService.getStats(year)
+      ]);
+      setExpenses(list.data || []);
+      setStats(s.data);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [month, category, searchTerm, year]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  if (!isAdmin) return <div className="expenses-container"><div className="error-message">Unauthorized</div></div>;
+
+  const topCategory = useMemo(() => {
+    if (!stats?.categoryTotals) return '-';
+    const entries = Object.entries(stats.categoryTotals);
+    if (entries.length === 0) return '-';
+    entries.sort((a, b) => b[1] - a[1]);
+    return `${entries[0][0]} (${fmtMAD(entries[0][1])})`;
+  }, [stats]);
+
+  const handleCreate = () => { setEditing(null); setShowForm(true); };
+  const handleEdit = (exp) => { setEditing(exp); setShowForm(true); };
+  const handleDelete = async (exp) => {
+    if (!window.confirm('Delete this expense?')) return;
+    try { setLoading(true); await expenseService.deleteExpense(exp._id); await loadData(); }
+    catch (e) { setError(e.message); }
+    finally { setLoading(false); }
+  };
+
+  if (loading && !showForm) {
+    return <div className="expenses-container"><div className="loading-message"><h3>Loading expenses...</h3><p>Please wait while we fetch the expense information.</p></div></div>;
+  }
+
+  if (showForm) {
+    return (
+      <ExpenseForm
+        initial={editing}
+        onCancel={() => { setShowForm(false); setEditing(null); }}
+        onSaved={async () => { setShowForm(false); setEditing(null); await loadData(); }}
+      />
+    );
+  }
+
+  return (
+    <div className="expenses-container">
+      <div className="expenses-header">
+        <div className="header-title">
+          <h2>📊 Expenses</h2>
+          <p>Track building expenses</p>
+        </div>
+        {stats && (
+          <div className="expenses-stats">
+            <div className="stat-card"><span className="stat-number">{fmtMAD(stats.currentMonthTotal)}</span><span className="stat-label">This Month</span></div>
+            <div className="stat-card"><span className="stat-number">{fmtMAD(stats.grandTotal)}</span><span className="stat-label">Year To Date</span></div>
+            <div className="stat-card"><span className="stat-number">{topCategory}</span><span className="stat-label">Top Category</span></div>
+          </div>
+        )}
+      </div>
+
+      <div className="expenses-controls">
+        <div className="search-filters">
+          <input type="text" placeholder="🔍 Search description or vendor..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="search-input" />
+          <input type="month" value={month} onChange={(e) => setMonth(e.target.value)} className="filter-select" />
+          <select value={category} onChange={(e) => setCategory(e.target.value)} className="filter-select">
+            {categories.map(c => (<option key={c.value} value={c.value}>{c.label}</option>))}
+          </select>
+        </div>
+        <button onClick={handleCreate} className="add-expense-btn">+ Add Expense</button>
+      </div>
+
+      {error && <div className="error-message">❌ {error}</div>}
+
+      {expenses.length === 0 ? (
+        <div className="no-expenses"><h3>No expenses found</h3><p>Try adjusting your filters or add your first expense.</p></div>
+      ) : (
+        <div className="expenses-table-container">
+          <table className="expenses-table">
+            <thead>
+              <tr>
+                <th>Date</th><th>Description</th><th>Category</th><th>Vendor</th><th style={{ textAlign: 'right' }}>Amount</th><th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {expenses.map(exp => (
+                <tr key={exp._id}>
+                  <td className="date-cell">{new Date(exp.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</td>
+                  <td className="description-cell">{exp.description}</td>
+                  <td className="category-cell"><span className={`category-badge ${exp.category}`}>{exp.category}</span></td>
+                  <td className="vendor-cell">{exp.vendor || '-'}</td>
+                  <td className="amount-cell" style={{ textAlign: 'right' }}>{fmtMAD(exp.amount)}</td>
+                  <td className="actions-cell">
+                    <button className="edit-btn" onClick={() => handleEdit(exp)} title="Edit">✏️</button>
+                    <button className="delete-btn" onClick={() => handleDelete(exp)} title="Delete">🗑️</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {expenses.length > 0 && (<div className="results-summary">Showing {expenses.length} expenses</div>)}
+    </div>
+  );
+};
+
+const ExpenseForm = ({ initial, onCancel, onSaved }) => {
+  const [form, setForm] = useState({
+    amount: initial?.amount || '',
+    description: initial?.description || '',
+    category: initial?.category || 'other',
+    date: initial ? new Date(initial.date).toISOString().split('T')[0] : new Date().toISOString().split('T')[0],
+    vendor: initial?.vendor || '',
+    notes: initial?.notes || '',
+    receiptUrl: initial?.receiptUrl || ''
+  });
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState('');
+
+  const handleChange = (e) => { const { name, value } = e.target; setForm(prev => ({ ...prev, [name]: value })); };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.amount || !form.description || !form.category || !form.date) {
+      setErr('Please fill in all required fields');
+      return;
+    }
+    try {
+      setLoading(true);
+      setErr('');
+      if (initial?._id) await expenseService.updateExpense(initial._id, form);
+      else await expenseService.createExpense(form);
+      await onSaved();
+    } catch (e) {
+      setErr(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-container">
+        <div className="modal-header">
+          <h3>{initial ? 'Edit Expense' : 'Add Expense'}</h3>
+          <button onClick={onCancel} className="close-btn" disabled={loading}>×</button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="expense-form">
+          {err && <div className="form-error">❌ {err}</div>}
+
+          <div className="form-row">
+            <div className="form-group">
+              <label htmlFor="amount">Amount (MAD) *</label>
+              <input type="number" id="amount" name="amount" value={form.amount} onChange={handleChange} min="0" step="0.01" required disabled={loading} />
+            </div>
+            <div className="form-group">
+              <label htmlFor="date">Date *</label>
+              <input type="date" id="date" name="date" value={form.date} onChange={handleChange} required disabled={loading} />
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="description">Description *</label>
+            <input type="text" id="description" name="description" value={form.description} onChange={handleChange} placeholder="e.g., Lobby cleaning" required disabled={loading} />
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label htmlFor="category">Category *</label>
+              <select id="category" name="category" value={form.category} onChange={handleChange} required disabled={loading}>
+                {categories.filter(c => c.value !== 'all').map(c => (<option key={c.value} value={c.value}>{c.label}</option>))}
+              </select>
+            </div>
+            <div className="form-group">
+              <label htmlFor="vendor">Vendor</label>
+              <input type="text" id="vendor" name="vendor" value={form.vendor} onChange={handleChange} placeholder="Supplier/Company" disabled={loading} />
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="notes">Notes</label>
+            <textarea id="notes" name="notes" value={form.notes} onChange={handleChange} rows="3" disabled={loading} />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="receiptUrl">Receipt URL (optional)</label>
+            <input type="url" id="receiptUrl" name="receiptUrl" value={form.receiptUrl} onChange={handleChange} placeholder="https://..." disabled={loading} />
+          </div>
+
+          <div className="modal-actions">
+            <button type="button" onClick={onCancel} className="cancel-btn" disabled={loading}>Cancel</button>
+            <button type="submit" className="confirm-btn" disabled={loading}>{loading ? 'Saving...' : (initial ? 'Update Expense' : 'Create Expense')}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Expenses;

--- a/client/src/components/Expenses.js
+++ b/client/src/components/Expenses.js
@@ -36,6 +36,15 @@ const Expenses = () => {
   const year = useMemo(() => parseInt(month.slice(0, 4), 10), [month]);
 
   const loadData = useCallback(async () => {
+    // Prevent admin-only calls when not admin
+    if (!isAdmin) {
+      setLoading(false);
+      setError('');
+      setExpenses([]);
+      setStats(null);
+      return;
+    }
+
     setLoading(true);
     setError('');
     try {
@@ -50,14 +59,13 @@ const Expenses = () => {
     } finally {
       setLoading(false);
     }
-  }, [month, category, searchTerm, year]);
+  }, [isAdmin, month, category, searchTerm, year]);
 
   useEffect(() => {
     loadData();
   }, [loadData]);
 
-  if (!isAdmin) return <div className="expenses-container"><div className="error-message">Unauthorized</div></div>;
-
+  // Move all hooks above; derive memo after hooks
   const topCategory = useMemo(() => {
     if (!stats?.categoryTotals) return '-';
     const entries = Object.entries(stats.categoryTotals);

--- a/client/src/components/Expenses.js
+++ b/client/src/components/Expenses.js
@@ -58,7 +58,7 @@ const Expenses = () => {
       const [list, s, ov] = await Promise.all([
         expenseService.getExpenses({ month, category, q: searchTerm }),
         expenseService.getStats(year),
-        expenseService.getFinanceOverview(month)
+        expenseService.getFinanceOverview() // CHANGED: overall (not month-scoped)
       ]);
       setExpenses(list.data || []);
       setStats(s.data);
@@ -186,10 +186,12 @@ const Expenses = () => {
           <div className="stat-card"><span className="stat-number">{fmtMAD(stats?.currentMonthTotal || 0)}</span><span className="stat-label">This Month</span></div>
           <div className="stat-card"><span className="stat-number">{fmtMAD(stats?.grandTotal || 0)}</span><span className="stat-label">Year To Date</span></div>
           <div className="stat-card"><span className="stat-number">{topCategory}</span><span className="stat-label">Top Category</span></div>
-          <div className="stat-card"><span className="stat-number">{fmtMAD(overview?.paidRevenue || 0)}</span><span className="stat-label">Collected (Confirmed)</span></div>
-          <div className="stat-card"><span className="stat-number">{fmtMAD(overview?.allocatedToExpenses || 0)}</span><span className="stat-label">Allocated</span></div>
+
+          {/* CHANGED: make finance cards clearly all-time */}
+          <div className="stat-card"><span className="stat-number">{fmtMAD(overview?.paidRevenue || 0)}</span><span className="stat-label">Collected (All‑Time)</span></div>
+          <div className="stat-card"><span className="stat-number">{fmtMAD(overview?.allocatedToExpenses || 0)}</span><span className="stat-label">Allocated (All‑Time)</span></div>
           <div className="stat-card"><span className="stat-number">{fmtMAD(overview?.fundBalance || 0)}</span><span className="stat-label">Fund Balance</span></div>
-          <div className="stat-card"><span className="stat-number">{fmtMAD(overview?.outstandingExpenses || 0)}</span><span className="stat-label">Outstanding</span></div>
+          <div className="stat-card"><span className="stat-number">{fmtMAD(overview?.outstandingExpenses || 0)}</span><span className="stat-label">Outstanding (All‑Time)</span></div>
         </div>
       </div>
 

--- a/client/src/components/Expenses.js
+++ b/client/src/components/Expenses.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { expenseService } from '../services/expenseService';
+import { useToast } from '../contexts/ToastContext';
 import './Expenses.css';
 
 const categories = [
@@ -371,6 +372,7 @@ const ExpenseForm = ({ initial, onCancel, onSaved }) => {
 };
 
 const AllocateModal = ({ expense, overview, onCancel, onSaved }) => {
+  const { showSuccess } = useToast();
   const allocated = (expense.allocations || []).reduce((s,a)=>s + (a.amount||0), 0);
   const remainingForExpense = Math.max(0, Number(expense.amount||0) - allocated);
   const fundBalance = Number(overview?.fundBalance || 0);
@@ -395,6 +397,7 @@ const AllocateModal = ({ expense, overview, onCancel, onSaved }) => {
       setLoading(true);
       setErr('');
       await expenseService.allocateExpense(expense._id, { amount: amt, note: form.note });
+      showSuccess(`Successfully allocated ${amt.toFixed(2)} MAD to "${expense.description}"`);
       await onSaved();
     } catch (e) {
       setErr(e.message);

--- a/client/src/components/PaymentManagement.css
+++ b/client/src/components/PaymentManagement.css
@@ -594,6 +594,24 @@
   margin-top: 2px;
 }
 
+.rejection-notice {
+  background-color: #fff3cd;
+  border: 1px solid #ffeaa7;
+  border-radius: 8px;
+  padding: 12px;
+  margin: 16px 0;
+  color: #856404;
+}
+
+.rejection-notice p {
+  margin: 4px 0;
+}
+
+.rejection-notice em {
+  color: #dc3545;
+  font-weight: 500;
+}
+
 /* Animations */
 @keyframes fadeIn {
   from {

--- a/client/src/components/PaymentManagement.css
+++ b/client/src/components/PaymentManagement.css
@@ -581,6 +581,19 @@
   transform: none;
 }
 
+/* Rejection Status Styles */
+.status-rejected {
+  background-color: #dc3545;
+  color: white;
+}
+
+.rejection-reason {
+  font-size: 0.8em;
+  color: #dc3545;
+  font-style: italic;
+  margin-top: 2px;
+}
+
 /* Animations */
 @keyframes fadeIn {
   from {

--- a/client/src/components/PaymentManagement.js
+++ b/client/src/components/PaymentManagement.js
@@ -163,6 +163,8 @@ const PaymentManagement = () => {
         return 'status-pending';
       case 'overdue':
         return 'status-overdue';
+      case 'rejected':
+        return 'status-rejected';
       default:
         return 'status-pending';
     }
@@ -259,6 +261,7 @@ const PaymentManagement = () => {
             <option value="submitted">Submitted</option>
             <option value="paid">Paid</option>
             <option value="overdue">Overdue</option>
+            <option value="rejected">Rejected</option>
           </select>
         </div>
         
@@ -324,6 +327,7 @@ const PaymentManagement = () => {
                   <td className="status-cell">
                     <span className={`status-badge ${getStatusBadge(payment.status)}`}>
                       {payment.status === 'submitted' ? 'Awaiting Confirmation' : 
+                       payment.status === 'rejected' ? 'Rejected' :
                        payment.status.charAt(0).toUpperCase() + payment.status.slice(1)}
                     </span>
                     {payment.confirmation?.confirmedAt && (
@@ -332,17 +336,20 @@ const PaymentManagement = () => {
                     {payment.paymentSubmission?.submittedAt && (
                       <div className="payment-date">Submitted: {formatDate(payment.paymentSubmission.submittedAt)}</div>
                     )}
+                    {payment.status === 'rejected' && payment.confirmation?.adminNotes && (
+                      <div className="rejection-reason">Reason: {payment.confirmation.adminNotes}</div>
+                    )}
                   </td>
                   <td className="actions-cell">
                     {/* Tenant Actions */}
-                    {!isAdmin && (payment.status === 'pending' || payment.status === 'overdue') && (
+                    {!isAdmin && (payment.status === 'pending' || payment.status === 'overdue' || payment.status === 'rejected') && (
                       <button
                         onClick={() => handleSubmitPayment(payment)}
                         className="pay-btn"
                         disabled={processingPayment === payment._id}
                         title="Submit payment proof"
                       >
-                        {processingPayment === payment._id ? '⏳' : '💳 Pay'}
+                        {processingPayment === payment._id ? '⏳' : payment.status === 'rejected' ? '🔄 Resubmit' : '💳 Pay'}
                       </button>
                     )}
                     

--- a/client/src/components/PaymentManagement.js
+++ b/client/src/components/PaymentManagement.js
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { paymentService } from '../services/paymentService';
 import { useAuth } from '../contexts/AuthContext';
+import { useToast } from '../contexts/ToastContext';
 import CreatePayment from './CreatePayment';
 import './PaymentManagement.css';
 
 const PaymentManagement = () => {
   const { user, isAdmin } = useAuth();
+  const { showSuccess } = useToast();
   
   // Shared states
   const [loading, setLoading] = useState(true);
@@ -69,6 +71,9 @@ const PaymentManagement = () => {
       setSelectedPayment(null);
       loadData(); // Refresh data
       
+      // Add success toast for tenant payment submission
+      showSuccess(`Payment proof submitted successfully! Your ${selectedPayment.description} payment is now awaiting admin confirmation.`);
+      
       console.log('Payment submitted successfully');
     } catch (error) {
       console.error('Error submitting payment:', error);
@@ -92,6 +97,9 @@ const PaymentManagement = () => {
       setShowConfirmPayment(false);
       setSelectedPayment(null);
       loadData(); // Refresh data
+      
+      // Add success toast for admin payment confirmation
+      showSuccess(`Payment confirmed! ${selectedPayment.amount} MAD collected from ${selectedPayment.resident?.name} for ${selectedPayment.description}.`);
       
       console.log('Payment confirmed successfully');
     } catch (error) {

--- a/client/src/components/PaymentManagement.js
+++ b/client/src/components/PaymentManagement.js
@@ -7,7 +7,7 @@ import './PaymentManagement.css';
 
 const PaymentManagement = () => {
   const { user, isAdmin } = useAuth();
-  const { showSuccess, showWarning } = useToast(); // Changed from showError to showWarning
+  const { showSuccess, showWarning, showError } = useToast(); // Added showError back for genuine errors
   
   // Shared states
   const [loading, setLoading] = useState(true);
@@ -69,15 +69,36 @@ const PaymentManagement = () => {
       
       setShowSubmitPayment(false);
       setSelectedPayment(null);
+      setError(''); // Clear any existing page errors
       loadData(); // Refresh data
       
       // Add success toast for tenant payment submission
-      showSuccess(`Payment proof submitted successfully! Your ${selectedPayment.description} payment is now awaiting admin confirmation.`);
+      const isResubmission = selectedPayment.status === 'rejected';
+      showSuccess(`Payment proof ${isResubmission ? 'resubmitted' : 'submitted'} successfully! Your ${selectedPayment.description} payment is now awaiting admin confirmation.`);
       
       console.log('Payment submitted successfully');
     } catch (error) {
       console.error('Error submitting payment:', error);
-      setError(error.message);
+      
+      // Clear page error and show toast instead
+      setError('');
+      
+      // Handle different types of errors with appropriate toasts
+      if (error.message.includes('already been submitted or confirmed')) {
+        showError('This payment has already been processed and cannot be resubmitted.');
+      } else if (error.message.includes('Payment method and payment date are required')) {
+        showError('Please fill in all required fields.');
+      } else if (error.message.includes('Payment not found')) {
+        showError('Payment not found. Please refresh the page and try again.');
+      } else if (error.message.includes('only submit payment for your own charges')) {
+        showError('You can only submit payments for your own charges.');
+      } else {
+        showError('Failed to submit payment. Please try again.');
+      }
+      
+      // Close modal on error
+      setShowSubmitPayment(false);
+      setSelectedPayment(null);
     } finally {
       setProcessingPayment(null);
     }
@@ -275,7 +296,7 @@ const PaymentManagement = () => {
 
       {/* Error message */}
       {error && (
-        <div className="error-message">
+        <div className="error-message" style={{ display: 'none' }}>
           ❌ {error}
         </div>
       )}
@@ -416,7 +437,7 @@ const PaymentManagement = () => {
   );
 };
 
-// Submit Payment Modal Component (Tenant)
+// Submit Payment Modal Component (Tenant) - Updated with better error handling
 const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
   const [formData, setFormData] = useState({
     paymentMethod: 'bank_transfer',
@@ -425,14 +446,35 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
     notes: ''
   });
   const [loading, setLoading] = useState(false);
+  const [formError, setFormError] = useState(''); // Local form validation errors only
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setFormError(''); // Clear local errors
+    
+    // Basic client-side validation
+    if (!formData.paymentMethod || !formData.paymentDate) {
+      setFormError('Please fill in all required fields.');
+      return;
+    }
+    
+    // Validate payment date is not in the future
+    const paymentDate = new Date(formData.paymentDate);
+    const today = new Date();
+    today.setHours(23, 59, 59, 999); // End of today
+    
+    if (paymentDate > today) {
+      setFormError('Payment date cannot be in the future.');
+      return;
+    }
+    
     setLoading(true);
     
     try {
       await onConfirm(formData);
+      // Success is handled by parent component
     } catch (error) {
+      // Let parent handle the error with toast
       console.error('Error submitting payment:', error);
     } finally {
       setLoading(false);
@@ -445,13 +487,18 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
       ...prev,
       [name]: value
     }));
+    
+    // Clear form error when user starts typing
+    if (formError) {
+      setFormError('');
+    }
   };
 
   return (
     <div className="modal-overlay">
       <div className="modal-container">
         <div className="modal-header">
-          <h3>💳 Submit Payment Proof</h3>
+          <h3>💳 {payment.status === 'rejected' ? 'Resubmit' : 'Submit'} Payment Proof</h3>
           <button onClick={onCancel} className="close-btn">×</button>
         </div>
 
@@ -460,7 +507,22 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
           <p><strong>Amount Due:</strong> {payment.amount} MAD</p>
           <p><strong>Period:</strong> {payment.period}</p>
           <p><strong>Due Date:</strong> {new Date(payment.dueDate).toLocaleDateString()}</p>
+          {payment.status === 'rejected' && (
+            <div className="rejection-notice">
+              <p><strong>Previous submission was rejected.</strong></p>
+              {payment.confirmation?.adminNotes && (
+                <p><em>Reason: {payment.confirmation.adminNotes}</em></p>
+              )}
+            </div>
+          )}
         </div>
+
+        {/* Show only local form validation errors */}
+        {formError && (
+          <div className="form-error">
+            {formError}
+          </div>
+        )}
 
         <form onSubmit={handleSubmit} className="submit-payment-form">
           <div className="form-group">
@@ -490,6 +552,7 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
               onChange={handleChange}
               required
               disabled={loading}
+              max={new Date().toISOString().split('T')[0]} // Prevent future dates
             />
           </div>
 
@@ -533,7 +596,7 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
               className="confirm-btn"
               disabled={loading}
             >
-              {loading ? 'Submitting...' : 'Submit Payment Proof'}
+              {loading ? 'Submitting...' : payment.status === 'rejected' ? 'Resubmit Payment Proof' : 'Submit Payment Proof'}
             </button>
           </div>
         </form>

--- a/client/src/components/PaymentManagement.js
+++ b/client/src/components/PaymentManagement.js
@@ -7,7 +7,7 @@ import './PaymentManagement.css';
 
 const PaymentManagement = () => {
   const { user, isAdmin } = useAuth();
-  const { showSuccess } = useToast();
+  const { showSuccess, showError } = useToast();
   
   // Shared states
   const [loading, setLoading] = useState(true);
@@ -118,6 +118,10 @@ const PaymentManagement = () => {
         await paymentService.rejectPayment(payment._id, 'Payment submission rejected by admin');
         
         loadData(); // Refresh data
+        
+        // Add error toast for payment rejection
+        showError(`Payment rejected! ${payment.resident?.name}'s payment for ${payment.description} has been declined.`);
+        
         console.log('Payment rejected successfully');
       } catch (error) {
         console.error('Error rejecting payment:', error);
@@ -132,6 +136,9 @@ const PaymentManagement = () => {
   const handleCreateBulkSuccess = () => {
     setShowCreateBulk(false);
     loadData(); // Refresh data
+    
+    // Add success toast for payment creation
+    showSuccess('New payments created successfully! Residents have been notified of their payment obligations.');
   };
 
   // Filter payments based on search and status

--- a/client/src/components/PaymentManagement.js
+++ b/client/src/components/PaymentManagement.js
@@ -7,7 +7,7 @@ import './PaymentManagement.css';
 
 const PaymentManagement = () => {
   const { user, isAdmin } = useAuth();
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showWarning } = useToast(); // Changed from showError to showWarning
   
   // Shared states
   const [loading, setLoading] = useState(true);
@@ -119,8 +119,8 @@ const PaymentManagement = () => {
         
         loadData(); // Refresh data
         
-        // Add error toast for payment rejection
-        showError(`Payment rejected! ${payment.resident?.name}'s payment for ${payment.description} has been declined.`);
+        // Updated to use warning toast (amber with "!" icon) for payment rejection
+        showWarning(`Payment rejected! ${payment.resident?.name}'s payment for ${payment.description} has been declined and can be resubmitted.`);
         
         console.log('Payment rejected successfully');
       } catch (error) {

--- a/client/src/services/expenseService.js
+++ b/client/src/services/expenseService.js
@@ -1,0 +1,59 @@
+const API_BASE_URL = 'http://localhost:5000/api';
+
+const getAuthHeaders = () => {
+  const token = localStorage.getItem('token');
+  return {
+    'Content-Type': 'application/json',
+    ...(token && { Authorization: `Bearer ${token}` })
+  };
+};
+
+export const expenseService = {
+  getExpenses: async (params = {}) => {
+    const url = new URL(`${API_BASE_URL}/expenses`);
+    if (params.month) url.searchParams.append('month', params.month);
+    if (params.category && params.category !== 'all') url.searchParams.append('category', params.category);
+    if (params.q) url.searchParams.append('q', params.q);
+    const res = await fetch(url.toString(), { headers: getAuthHeaders() });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to fetch expenses');
+    return data;
+  },
+  createExpense: async (expense) => {
+    const res = await fetch(`${API_BASE_URL}/expenses`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(expense)
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to create expense');
+    return data;
+  },
+  updateExpense: async (id, expense) => {
+    const res = await fetch(`${API_BASE_URL}/expenses/${id}`, {
+      method: 'PUT',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(expense)
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to update expense');
+    return data;
+  },
+  deleteExpense: async (id) => {
+    const res = await fetch(`${API_BASE_URL}/expenses/${id}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders()
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to delete expense');
+    return data;
+  },
+  getStats: async (year) => {
+    const url = new URL(`${API_BASE_URL}/expenses/stats`);
+    if (year) url.searchParams.append('year', year);
+    const res = await fetch(url.toString(), { headers: getAuthHeaders() });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to fetch expense stats');
+    return data;
+  }
+};

--- a/client/src/services/expenseService.js
+++ b/client/src/services/expenseService.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = 'http://localhost:5000/api';
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 
 const getAuthHeaders = () => {
   const token = localStorage.getItem('token');
@@ -19,6 +19,7 @@ export const expenseService = {
     if (!res.ok) throw new Error(data.error || 'Failed to fetch expenses');
     return data;
   },
+
   createExpense: async (expense) => {
     const res = await fetch(`${API_BASE_URL}/expenses`, {
       method: 'POST',
@@ -29,6 +30,7 @@ export const expenseService = {
     if (!res.ok) throw new Error(data.error || 'Failed to create expense');
     return data;
   },
+
   updateExpense: async (id, expense) => {
     const res = await fetch(`${API_BASE_URL}/expenses/${id}`, {
       method: 'PUT',
@@ -39,6 +41,7 @@ export const expenseService = {
     if (!res.ok) throw new Error(data.error || 'Failed to update expense');
     return data;
   },
+
   deleteExpense: async (id) => {
     const res = await fetch(`${API_BASE_URL}/expenses/${id}`, {
       method: 'DELETE',
@@ -48,12 +51,45 @@ export const expenseService = {
     if (!res.ok) throw new Error(data.error || 'Failed to delete expense');
     return data;
   },
+
   getStats: async (year) => {
     const url = new URL(`${API_BASE_URL}/expenses/stats`);
     if (year) url.searchParams.append('year', year);
     const res = await fetch(url.toString(), { headers: getAuthHeaders() });
     const data = await res.json();
     if (!res.ok) throw new Error(data.error || 'Failed to fetch expense stats');
+    return data;
+  },
+
+  // NEW: finance overview (optional month filter)
+  getFinanceOverview: async (month) => {
+    const url = new URL(`${API_BASE_URL}/expenses/overview`);
+    if (month) url.searchParams.append('month', month);
+    const res = await fetch(url.toString(), { headers: getAuthHeaders() });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to fetch finance overview');
+    return data;
+  },
+
+  // NEW: allocations
+  allocateExpense: async (id, payload) => {
+    const res = await fetch(`${API_BASE_URL}/expenses/${id}/allocate`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to allocate funds');
+    return data;
+  },
+
+  deleteAllocation: async (id, allocId) => {
+    const res = await fetch(`${API_BASE_URL}/expenses/${id}/allocations/${allocId}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders()
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to delete allocation');
     return data;
   }
 };

--- a/server/controllers/expenseController.js
+++ b/server/controllers/expenseController.js
@@ -1,0 +1,149 @@
+const Expense = require('../models/Expense');
+
+// GET /api/expenses?month=YYYY-MM&category=&q=
+const getExpenses = async (req, res) => {
+  try {
+    const { month, category, q } = req.query;
+    const query = {};
+    if (month) {
+      const [y, m] = month.split('-').map(n => parseInt(n, 10));
+      const start = new Date(y, m - 1, 1);
+      const end = new Date(y, m, 0, 23, 59, 59, 999);
+      query.date = { $gte: start, $lte: end };
+    }
+    if (category && category !== 'all') query.category = category;
+    if (q) query.$text = { $search: q };
+
+    const expenses = await Expense.find(query)
+      .sort({ date: -1 })
+      .populate('createdBy', 'name email');
+
+    res.json({ success: true, count: expenses.length, data: expenses });
+  } catch (err) {
+    console.error('Error fetching expenses:', err);
+    res.status(500).json({ success: false, error: 'Server error while fetching expenses' });
+  }
+};
+
+// POST /api/expenses
+const createExpense = async (req, res) => {
+  try {
+    const { amount, description, category, date, vendor = '', notes = '', receiptUrl = '' } = req.body;
+    if (!amount || !description || !category || !date) {
+      return res.status(400).json({ success: false, error: 'Amount, description, category and date are required' });
+    }
+    const expense = await Expense.create({
+      amount: parseFloat(amount),
+      description: description.trim(),
+      category,
+      date: new Date(date),
+      vendor: vendor.trim(),
+      notes: notes.trim(),
+      receiptUrl: receiptUrl.trim(),
+      createdBy: req.user._id
+    });
+    res.status(201).json({ success: true, data: expense });
+  } catch (err) {
+    console.error('Error creating expense:', err);
+    res.status(500).json({ success: false, error: 'Server error while creating expense' });
+  }
+};
+
+// PUT /api/expenses/:id
+const updateExpense = async (req, res) => {
+  try {
+    const { amount, description, category, date, vendor = '', notes = '', receiptUrl = '' } = req.body;
+    if (!amount || !description || !category || !date) {
+      return res.status(400).json({ success: false, error: 'Amount, description, category and date are required' });
+    }
+    const expense = await Expense.findByIdAndUpdate(
+      req.params.id,
+      {
+        amount: parseFloat(amount),
+        description: description.trim(),
+        category,
+        date: new Date(date),
+        vendor: vendor.trim(),
+        notes: notes.trim(),
+        receiptUrl: receiptUrl.trim()
+      },
+      { new: true, runValidators: true }
+    ).populate('createdBy', 'name email');
+
+    if (!expense) return res.status(404).json({ success: false, error: 'Expense not found' });
+    res.json({ success: true, data: expense });
+  } catch (err) {
+    console.error('Error updating expense:', err);
+    res.status(500).json({ success: false, error: 'Server error while updating expense' });
+  }
+};
+
+// DELETE /api/expenses/:id
+const deleteExpense = async (req, res) => {
+  try {
+    const expense = await Expense.findByIdAndDelete(req.params.id);
+    if (!expense) return res.status(404).json({ success: false, error: 'Expense not found' });
+    res.json({ success: true, data: { deletedExpenseId: req.params.id } });
+  } catch (err) {
+    console.error('Error deleting expense:', err);
+    res.status(500).json({ success: false, error: 'Server error while deleting expense' });
+  }
+};
+
+// GET /api/expenses/stats?year=YYYY
+const getExpenseStats = async (req, res) => {
+  try {
+    const year = parseInt(req.query.year, 10) || new Date().getFullYear();
+    const start = new Date(year, 0, 1);
+    const end = new Date(year + 1, 0, 0, 23, 59, 59, 999);
+
+    const [monthlyAgg, categoryAgg, ytdAgg] = await Promise.all([
+      Expense.aggregate([
+        { $match: { date: { $gte: start, $lte: end } } },
+        { $group: { _id: { $month: '$date' }, total: { $sum: '$amount' } } }
+      ]),
+      Expense.aggregate([
+        { $match: { date: { $gte: start, $lte: end } } },
+        { $group: { _id: '$category', total: { $sum: '$amount' } } }
+      ]),
+      Expense.aggregate([
+        { $match: { date: { $gte: start, $lte: end } } },
+        { $group: { _id: null, total: { $sum: '$amount' } } }
+      ])
+    ]);
+
+    const monthlyTotals = Array.from({ length: 12 }, (_, i) => {
+      const found = monthlyAgg.find(m => m._id === i + 1);
+      return found ? found.total : 0;
+    });
+
+    const categoryTotals = {};
+    categoryAgg.forEach(c => { categoryTotals[c._id] = c.total; });
+
+    const now = new Date();
+    const currentMonth = now.getFullYear() === year ? now.getMonth() : -1;
+    const monthTotal = currentMonth >= 0 ? monthlyTotals[currentMonth] : 0;
+
+    res.json({
+      success: true,
+      data: {
+        year,
+        monthlyTotals,
+        categoryTotals,
+        grandTotal: ytdAgg[0]?.total || 0,
+        currentMonthTotal: monthTotal
+      }
+    });
+  } catch (err) {
+    console.error('Error building expense stats:', err);
+    res.status(500).json({ success: false, error: 'Server error while building expense stats' });
+  }
+};
+
+module.exports = {
+  getExpenses,
+  createExpense,
+  updateExpense,
+  deleteExpense,
+  getExpenseStats
+};

--- a/server/controllers/paymentController.js
+++ b/server/controllers/paymentController.js
@@ -331,7 +331,7 @@ const rejectPayment = async (req, res) => {
     const payment = await Payment.findByIdAndUpdate(
       paymentId,
       {
-        status: 'pending', // Reset to pending
+        status: 'rejected', // Changed from 'pending' to 'rejected'
         'paymentSubmission.submittedAt': null,
         'paymentSubmission.paymentMethod': null,
         'paymentSubmission.paymentDate': null,
@@ -348,7 +348,7 @@ const rejectPayment = async (req, res) => {
         error: 'Payment not found'
       });
     }
-    
+
     console.log('2. Payment submission rejected');
     
     res.json({

--- a/server/controllers/paymentController.js
+++ b/server/controllers/paymentController.js
@@ -236,8 +236,8 @@ const submitPayment = async (req, res) => {
       });
     }
     
-    // Check if payment is in submittable state
-    if (payment.status !== 'pending' && payment.status !== 'overdue') {
+    // Check if payment is in submittable state - UPDATED to include 'rejected'
+    if (!['pending', 'overdue', 'rejected'].includes(payment.status)) {
       return res.status(400).json({
         success: false,
         error: 'Payment has already been submitted or confirmed'

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ require('dotenv').config();
 const authRoutes = require('./routes/auth');
 const userRoutes = require('./routes/users');
 const paymentRoutes = require('./routes/payments'); // Add this line
+const expensesRoutes = require('./routes/expenses');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -19,6 +20,7 @@ app.use(express.json()); // converts incoming json payloads to js objects
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/payments', paymentRoutes); // new payment route
+app.use('/api/expenses', expensesRoutes);
 
 // Basic route
 app.get('/', (req, res) => {

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+
+const categories = [
+  'cleaning', 'electricity', 'water', 'repairs', 'maintenance',
+  'security', 'salary', 'utilities', 'other'
+];
+
+const expenseSchema = new mongoose.Schema(
+  {
+    amount: { type: Number, required: true, min: 0 },
+    description: { type: String, required: true, trim: true },
+    category: { type: String, enum: categories, required: true },
+    date: { type: Date, required: true },
+    vendor: { type: String, trim: true, default: '' },
+    notes: { type: String, trim: true, default: '' },
+    receiptUrl: { type: String, trim: true, default: '' },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }
+  },
+  { timestamps: true }
+);
+
+expenseSchema.index({ date: -1 });
+expenseSchema.index({ category: 1 });
+expenseSchema.index({ description: 'text', vendor: 'text' });
+
+module.exports = mongoose.model('Expense', expenseSchema);

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -1,9 +1,27 @@
 const mongoose = require('mongoose');
 
 const categories = [
-  'cleaning', 'electricity', 'water', 'repairs', 'maintenance',
-  'security', 'salary', 'utilities', 'other'
+  'cleaning',
+  'electricity',
+  'water',
+  'repairs',
+  'maintenance',
+  'security',
+  'salary',
+  'utilities',
+  'other'
 ];
+
+const allocationSchema = new mongoose.Schema(
+  {
+    amount: { type: Number, required: true, min: 0 },
+    allocatedAt: { type: Date, default: Date.now },
+    allocatedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    note: { type: String, trim: true, default: '' },
+    source: { type: String, enum: ['fund'], default: 'fund' }
+  },
+  { _id: true }
+);
 
 const expenseSchema = new mongoose.Schema(
   {
@@ -14,13 +32,36 @@ const expenseSchema = new mongoose.Schema(
     vendor: { type: String, trim: true, default: '' },
     notes: { type: String, trim: true, default: '' },
     receiptUrl: { type: String, trim: true, default: '' },
-    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+
+    // NEW: allocations applied from collected fund
+    allocations: { type: [allocationSchema], default: [] }
   },
-  { timestamps: true }
+  { 
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true }
+  }
 );
 
+// Indexes
 expenseSchema.index({ date: -1 });
 expenseSchema.index({ category: 1 });
 expenseSchema.index({ description: 'text', vendor: 'text' });
+expenseSchema.index({ 'allocations.allocatedAt': -1 });
+
+// Virtuals
+expenseSchema.virtual('allocatedTotal').get(function () {
+  return (this.allocations || []).reduce((s, a) => s + (a.amount || 0), 0);
+});
+expenseSchema.virtual('remainingAmount').get(function () {
+  const rem = Number(this.amount || 0) - Number(this.allocatedTotal || 0);
+  return rem < 0 ? 0 : rem;
+});
+expenseSchema.virtual('computedStatus').get(function () {
+  if ((this.allocatedTotal || 0) <= 0) return 'unpaid';
+  if ((this.allocatedTotal || 0) < (this.amount || 0)) return 'partially_paid';
+  return 'paid';
+});
 
 module.exports = mongoose.model('Expense', expenseSchema);

--- a/server/models/Payment.js
+++ b/server/models/Payment.js
@@ -37,7 +37,7 @@ const paymentSchema = new mongoose.Schema({
   // Payment status - ENHANCED
   status: {
     type: String,
-    enum: ['pending', 'submitted', 'paid', 'overdue'], // Added 'submitted'
+    enum: ['pending', 'submitted', 'paid', 'overdue', 'rejected'], // Added 'rejected'
     default: 'pending'
   },
   

--- a/server/routes/expenses.js
+++ b/server/routes/expenses.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getExpenses,
+  createExpense,
+  updateExpense,
+  deleteExpense,
+  getExpenseStats
+} = require('../controllers/expenseController');
+const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+
+router.use(authenticateToken);
+router.use(requireAdmin);
+
+router.get('/stats', getExpenseStats);
+router.get('/', getExpenses);
+router.post('/', createExpense);
+router.put('/:id', updateExpense);
+router.delete('/:id', deleteExpense);
+
+module.exports = router;

--- a/server/routes/expenses.js
+++ b/server/routes/expenses.js
@@ -5,17 +5,28 @@ const {
   createExpense,
   updateExpense,
   deleteExpense,
-  getExpenseStats
+  getExpenseStats,
+  allocateExpense,
+  deleteAllocation,
+  getFinanceOverview
 } = require('../controllers/expenseController');
 const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
 
 router.use(authenticateToken);
 router.use(requireAdmin);
 
+// Stats + finance overview
 router.get('/stats', getExpenseStats);
+router.get('/overview', getFinanceOverview);
+
+// CRUD
 router.get('/', getExpenses);
 router.post('/', createExpense);
 router.put('/:id', updateExpense);
 router.delete('/:id', deleteExpense);
+
+// Allocations
+router.post('/:id/allocate', allocateExpense);
+router.delete('/:id/allocations/:allocId', deleteAllocation);
 
 module.exports = router;


### PR DESCRIPTION
-updated the payment management compoent to properly handle resubmission on "rejected payments"
- updated error display by adopting toast errors/ success notifications when resubmitting a payment instead of inline/inconsistent errors.
- fully functional and handles edge cases (already submitte etc..)