### PR TITLE
Fix resubmit throwing an error on tenant-side

### DIFF
--- a/client/src/components/PaymentManagement.css
+++ b/client/src/components/PaymentManagement.css
@@ -594,6 +594,24 @@
   margin-top: 2px;
 }
 
+.rejection-notice {
+  background-color: #fff3cd;
+  border: 1px solid #ffeaa7;
+  border-radius: 8px;
+  padding: 12px;
+  margin: 16px 0;
+  color: #856404;
+}
+
+.rejection-notice p {
+  margin: 4px 0;
+}
+
+.rejection-notice em {
+  color: #dc3545;
+  font-weight: 500;
+}
+
 /* Animations */
 @keyframes fadeIn {
   from {

--- a/client/src/components/PaymentManagement.js
+++ b/client/src/components/PaymentManagement.js
@@ -7,7 +7,7 @@ import './PaymentManagement.css';
 
 const PaymentManagement = () => {
   const { user, isAdmin } = useAuth();
-  const { showSuccess, showWarning } = useToast(); // Changed from showError to showWarning
+  const { showSuccess, showWarning, showError } = useToast(); // Added showError back for genuine errors
   
   // Shared states
   const [loading, setLoading] = useState(true);
@@ -69,15 +69,36 @@ const PaymentManagement = () => {
       
       setShowSubmitPayment(false);
       setSelectedPayment(null);
+      setError(''); // Clear any existing page errors
       loadData(); // Refresh data
       
       // Add success toast for tenant payment submission
-      showSuccess(`Payment proof submitted successfully! Your ${selectedPayment.description} payment is now awaiting admin confirmation.`);
+      const isResubmission = selectedPayment.status === 'rejected';
+      showSuccess(`Payment proof ${isResubmission ? 'resubmitted' : 'submitted'} successfully! Your ${selectedPayment.description} payment is now awaiting admin confirmation.`);
       
       console.log('Payment submitted successfully');
     } catch (error) {
       console.error('Error submitting payment:', error);
-      setError(error.message);
+      
+      // Clear page error and show toast instead
+      setError('');
+      
+      // Handle different types of errors with appropriate toasts
+      if (error.message.includes('already been submitted or confirmed')) {
+        showError('This payment has already been processed and cannot be resubmitted.');
+      } else if (error.message.includes('Payment method and payment date are required')) {
+        showError('Please fill in all required fields.');
+      } else if (error.message.includes('Payment not found')) {
+        showError('Payment not found. Please refresh the page and try again.');
+      } else if (error.message.includes('only submit payment for your own charges')) {
+        showError('You can only submit payments for your own charges.');
+      } else {
+        showError('Failed to submit payment. Please try again.');
+      }
+      
+      // Close modal on error
+      setShowSubmitPayment(false);
+      setSelectedPayment(null);
     } finally {
       setProcessingPayment(null);
     }
@@ -275,7 +296,7 @@ const PaymentManagement = () => {
 
       {/* Error message */}
       {error && (
-        <div className="error-message">
+        <div className="error-message" style={{ display: 'none' }}>
           ❌ {error}
         </div>
       )}
@@ -416,7 +437,7 @@ const PaymentManagement = () => {
   );
 };
 
-// Submit Payment Modal Component (Tenant)
+// Submit Payment Modal Component (Tenant) - Updated with better error handling
 const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
   const [formData, setFormData] = useState({
     paymentMethod: 'bank_transfer',
@@ -425,14 +446,35 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
     notes: ''
   });
   const [loading, setLoading] = useState(false);
+  const [formError, setFormError] = useState(''); // Local form validation errors only
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setFormError(''); // Clear local errors
+    
+    // Basic client-side validation
+    if (!formData.paymentMethod || !formData.paymentDate) {
+      setFormError('Please fill in all required fields.');
+      return;
+    }
+    
+    // Validate payment date is not in the future
+    const paymentDate = new Date(formData.paymentDate);
+    const today = new Date();
+    today.setHours(23, 59, 59, 999); // End of today
+    
+    if (paymentDate > today) {
+      setFormError('Payment date cannot be in the future.');
+      return;
+    }
+    
     setLoading(true);
     
     try {
       await onConfirm(formData);
+      // Success is handled by parent component
     } catch (error) {
+      // Let parent handle the error with toast
       console.error('Error submitting payment:', error);
     } finally {
       setLoading(false);
@@ -445,13 +487,18 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
       ...prev,
       [name]: value
     }));
+    
+    // Clear form error when user starts typing
+    if (formError) {
+      setFormError('');
+    }
   };
 
   return (
     <div className="modal-overlay">
       <div className="modal-container">
         <div className="modal-header">
-          <h3>💳 Submit Payment Proof</h3>
+          <h3>💳 {payment.status === 'rejected' ? 'Resubmit' : 'Submit'} Payment Proof</h3>
           <button onClick={onCancel} className="close-btn">×</button>
         </div>
 
@@ -460,7 +507,22 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
           <p><strong>Amount Due:</strong> {payment.amount} MAD</p>
           <p><strong>Period:</strong> {payment.period}</p>
           <p><strong>Due Date:</strong> {new Date(payment.dueDate).toLocaleDateString()}</p>
+          {payment.status === 'rejected' && (
+            <div className="rejection-notice">
+              <p><strong>Previous submission was rejected.</strong></p>
+              {payment.confirmation?.adminNotes && (
+                <p><em>Reason: {payment.confirmation.adminNotes}</em></p>
+              )}
+            </div>
+          )}
         </div>
+
+        {/* Show only local form validation errors */}
+        {formError && (
+          <div className="form-error">
+            {formError}
+          </div>
+        )}
 
         <form onSubmit={handleSubmit} className="submit-payment-form">
           <div className="form-group">
@@ -490,6 +552,7 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
               onChange={handleChange}
               required
               disabled={loading}
+              max={new Date().toISOString().split('T')[0]} // Prevent future dates
             />
           </div>
 
@@ -533,7 +596,7 @@ const SubmitPaymentModal = ({ payment, onConfirm, onCancel }) => {
               className="confirm-btn"
               disabled={loading}
             >
-              {loading ? 'Submitting...' : 'Submit Payment Proof'}
+              {loading ? 'Submitting...' : payment.status === 'rejected' ? 'Resubmit Payment Proof' : 'Submit Payment Proof'}
             </button>
           </div>
         </form>

--- a/server/controllers/paymentController.js
+++ b/server/controllers/paymentController.js
@@ -236,8 +236,8 @@ const submitPayment = async (req, res) => {
       });
     }
     
-    // Check if payment is in submittable state
-    if (payment.status !== 'pending' && payment.status !== 'overdue') {
+    // Check if payment is in submittable state - UPDATED to include 'rejected'
+    if (!['pending', 'overdue', 'rejected'].includes(payment.status)) {
       return res.status(400).json({
         success: false,
         error: 'Payment has already been submitted or confirmed'


### PR DESCRIPTION
- updated the payment management compoent to properly handle resubmission on "rejected payments"

- updated error display by adopting toast errors/ success notifications when resubmitting a payment instead of inline/inconsistent errors.

- fully functional and handles edge cases (already submitte etc..)